### PR TITLE
Throw Exception on missing bean field when deserializing to custom type

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/src/main/java/com/alibaba/fastjson/JSON.java
@@ -99,6 +99,7 @@ public abstract class JSON implements JSONStreamAware, JSONAware {
         features |= Feature.AllowArbitraryCommas.getMask();
         features |= Feature.SortFeidFastMatch.getMask();
         features |= Feature.IgnoreNotMatch.getMask();
+        features |= Feature.ExceptionOnMissingBeanPrimitiveField.getMask();
         DEFAULT_PARSER_FEATURE = features;
     }
 

--- a/src/main/java/com/alibaba/fastjson/parser/Feature.java
+++ b/src/main/java/com/alibaba/fastjson/parser/Feature.java
@@ -120,7 +120,13 @@ public enum Feature {
      *
      * disable field smart match, improve performance in some scenarios.
      */
-    DisableFieldSmartMatch
+    DisableFieldSmartMatch,
+
+    /**
+     *
+     * throw an exception when a field is missing when deserializing a JSON object to a provided class.
+     */
+    ExceptionOnMissingBeanPrimitiveField
     ;
 
     Feature(){

--- a/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
+++ b/src/main/java/com/alibaba/fastjson/parser/deserializer/JavaBeanDeserializer.java
@@ -666,24 +666,32 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                 FieldInfo[] fieldInfoList = beanInfo.fields;
                 int size = fieldInfoList.length;
                 Object[] params = new Object[size];
+                boolean throwExceptionOnMissingBeanField = parser.isEnabled(Feature.ExceptionOnMissingBeanPrimitiveField);
                 for (int i = 0; i < size; ++i) {
                     FieldInfo fieldInfo = fieldInfoList[i];
                     Object param = fieldValues.get(fieldInfo.name);
                     if (param == null) {
                         Type fieldType = fieldInfo.fieldType;
                         if (fieldType == byte.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = (byte) 0;
                         } else if (fieldType == short.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = (short) 0;
                         } else if (fieldType == int.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = 0;
                         } else if (fieldType == long.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = 0L;
                         } else if (fieldType == float.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = 0F;
                         } else if (fieldType == double.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = 0D;
                         } else if (fieldType == boolean.class) {
+                            if (throwExceptionOnMissingBeanField) checkIfMissingBeanPrimitiveField(fieldValues, fieldInfo.name);
                             param = Boolean.FALSE;
                         }
                     }
@@ -725,6 +733,12 @@ public class JavaBeanDeserializer implements ObjectDeserializer {
                 childContext.object = object;
             }
             parser.setContext(context);
+        }
+    }
+
+    protected void checkIfMissingBeanPrimitiveField(Map<String, Object> fieldValues, String fieldName) throws JSONException {
+        if (!fieldValues.containsKey(fieldName)) {
+            throw new JSONException("Missing field '" + fieldName + "' to deserialize JSON to type '" + beanInfo.typeName + "'");
         }
     }
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_boolean.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_boolean.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_boolean extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":false,\"name\":\"wenshao\"}", Model.class);
         Assert.assertFalse(model.id);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_byte.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_byte.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_byte extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":0,\"name\":\"wenshao\"}", Model.class);
         Assert.assertEquals(0, model.id);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_double.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_double.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_double extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":0,\"name\":\"wenshao\"}", Model.class);
         Assert.assertTrue(model.id == 0);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_float.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_float.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_float extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":0,\"name\":\"wenshao\"}", Model.class);
         Assert.assertTrue(model.id == 0);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_int.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_int.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_int extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":0,\"name\":\"wenshao\"}", Model.class);
         Assert.assertEquals(0, model.id);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_long.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_long.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_long extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":0,\"name\":\"wenshao\"}", Model.class);
         Assert.assertEquals(0, model.id);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 

--- a/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_short.java
+++ b/src/test/java/com/alibaba/json/bvt/parser/creator/JSONCreatorTest_default_short.java
@@ -1,6 +1,7 @@
 package com.alibaba.json.bvt.parser.creator;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import com.alibaba.fastjson.annotation.JSONField;
 import junit.framework.TestCase;
@@ -9,11 +10,19 @@ import org.junit.Assert;
 public class JSONCreatorTest_default_short extends TestCase {
 
     public void test_create() throws Exception {
-        Model model = JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+        Model model = JSON.parseObject("{\"id\":0,\"name\":\"wenshao\"}", Model.class);
         Assert.assertEquals(0, model.id);
         Assert.assertEquals("wenshao", model.name);
     }
 
+    public void test_createMissingField() throws Exception {
+        try {
+            JSON.parseObject("{\"name\":\"wenshao\"}", Model.class);
+            fail();
+        } catch (JSONException e) {
+            assertEquals("Missing field 'id' to deserialize JSON to type 'com.alibaba.json.bvt.parser.creator." + getClass().getSimpleName() + "$Model'", e.getMessage());
+        }
+    }
 
     public static class Model {
 


### PR DESCRIPTION
Add a Deserializer Feature 'ExceptionOnMissingBeanPrimitiveField' to
make FastJSON throw a JSONExcpetion in case a primitive field is missing
when deserializing a JSON string to a custon type.

This makes fastJson 1.2.31 behave similarly to 1.2.1. The commit which
introduced the bahavioral change is
61ff5e84fec5022c2113288721f6435d84983a65